### PR TITLE
JPA

### DIFF
--- a/SpringData/jpa/ex1-hello-jpa-start/pom.xml
+++ b/SpringData/jpa/ex1-hello-jpa-start/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>jpa-basic</groupId>
+    <artifactId>ex1-hello-jpa</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- JPA 하이버네이트 -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.4.2.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
+        <!-- H2 데이터베이스 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- logback -->
+<!--
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.14</version>
+        </dependency>
+-->
+    </dependencies>
+
+</project>

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/JpaMain.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/JpaMain.java
@@ -1,0 +1,23 @@
+package hellojpa;
+
+import hellojpa.domain.Member;
+import jakarta.persistence.*;
+
+public class JpaMain {
+
+    public static void main(String[] args) {
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
+        tx.begin();
+        //code
+
+        Member member = new Member();
+        em.persist(member);
+        tx.commit();
+
+        em.close();
+        emf.close();
+    }
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Album.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Album.java
@@ -1,0 +1,14 @@
+package hellojpa.domain;
+
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Entity
+public class Album extends Item{
+    private String artist;
+    private String etc;
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/BaseEntity.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/BaseEntity.java
@@ -1,0 +1,17 @@
+package hellojpa.domain;
+
+
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+public class BaseEntity {
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+
+    @Override
+    public String toString() {
+
+        return super.toString();
+    }
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Book.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Book.java
@@ -1,0 +1,14 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Book extends Item{
+
+    private String author;
+    private String isbn;
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Category.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Category.java
@@ -1,0 +1,38 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PARENT_ID")
+    private Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Category> child = new ArrayList<>();
+
+    @ManyToMany
+    @JoinTable(name = "CATEGORY_ITEM",
+        joinColumns = @JoinColumn(name = "CATEGORY_ID"),
+        inverseJoinColumns = @JoinColumn(name = "ITEM_ID")
+    )
+    private List<Item> items = new ArrayList<>();
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Delivery.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Delivery.java
@@ -1,0 +1,24 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Delivery extends BaseEntity{
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String city;
+    private String street;
+    private String zipcode;
+    private DeliveryState status;
+
+    @OneToOne(mappedBy = "delivery", fetch = FetchType.LAZY)
+    private Order order;
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/DeliveryState.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/DeliveryState.java
@@ -1,0 +1,5 @@
+package hellojpa.domain;
+
+public enum DeliveryState {
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Item.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Item.java
@@ -1,0 +1,36 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+@Setter
+@Getter
+public abstract class Item extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ITEM_ID")
+    private Long id;
+
+    private int price;
+
+    private int stockQuantity;
+
+    @ManyToMany(mappedBy = "items")
+    private List<Category> categories = new ArrayList<>();
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Member.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Member.java
@@ -1,0 +1,30 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "MEMBER_ID")
+    private Long id;
+    private String name;
+
+    private String city;
+
+    private String zipcode;
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Movie.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Movie.java
@@ -1,0 +1,15 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Movie extends Item{
+
+    private String director;
+    private String actor;
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Order.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/Order.java
@@ -1,0 +1,51 @@
+package hellojpa.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "ORDERS")
+@Getter
+@Setter
+public class Order extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ORDER_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    private LocalDateTime orderdate;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "DELIVERY_ID")
+    private Delivery delivery;
+
+
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/OrderItem.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/OrderItem.java
@@ -1,0 +1,27 @@
+package hellojpa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Item item;
+
+    private int orderPrice;
+
+    private int count;
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/OrderStatus.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/OrderStatus.java
@@ -1,0 +1,8 @@
+package hellojpa.domain;
+
+
+
+
+public enum OrderStatus {
+    ORDER, CANCEL, PENDING
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/RoleType.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/java/hellojpa/domain/RoleType.java
@@ -1,0 +1,5 @@
+package hellojpa.domain;
+
+public enum RoleType {
+    MANAGER, USER
+}

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/META-INF/persistence.xml
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="hello">
+        <properties>
+            <!-- 필수 속성 -->
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:tcp://localhost/~/test"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!-- 옵션 -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.use_sql_comments"  value="true"/>
+            <property name="hibernate.jdbc.batch_size" value="10"/>
+            <property name="hibernate.hbm2ddl.auto" value="create" />
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/logback.xml
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%d{HH:mm} %-5level %logger{36} - %msg%n</Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.hibernate.orm.jdbc.bind" level="trace" />
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/sql/schema.sql
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/main/resources/sql/schema.sql
@@ -1,0 +1,4 @@
+CREATE table Order (
+    id bigint not null,
+
+)

--- a/SpringData/jpa/ex1-hello-jpa-start/src/test/java/ProxyTest.java
+++ b/SpringData/jpa/ex1-hello-jpa-start/src/test/java/ProxyTest.java
@@ -1,0 +1,41 @@
+import hellojpa.domain.Member;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import org.jboss.jandex.Main;
+
+public class ProxyTest {
+
+    public static void main(String[] args) {
+
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
+        tx.begin();
+        //code
+
+        Member member1 = new Member();
+        member1.setName("member1");
+        em.persist(member1);
+        em.flush();
+        em.clear();
+
+        Member m1 = em.find(Member.class, member1.getId());
+
+        System.out.println("m1 == m2: " + m1.getClass());
+        // 이미 영속성 컨텍스트에 올려놔서 원본을 가져옴.
+        // 진짜 이유 ?
+        // JPA에서는
+        // cascade <= 소유자가 하나 일때만 사용해야함. 단일 엔티티에 완전 종속적일 때, 라이프 사이클이 같다면 사용할만함
+        Member reference = em.getReference(Member.class, member1.getId());
+        System.out.println("reference = " + reference.getClass());
+
+        //항상 true가 되어야함.
+        System.out.println("a == a: " + (m1 == reference));
+        tx.commit();
+
+        em.close();
+        emf.close();
+    }
+}


### PR DESCRIPTION
* JPA를 왜 사용하는가? 객체와 DB의 서로 다른 패러다임을  컬렉션을 통해 객체지향적으로 다루기 위해서 나온 기술. 
* JPA의 연관관계 1: N, N : M, N: 1
* 관계의 주인 설정은 FK쪽으로
* 한 트랜잭션 내에서 같은 데이터를 가진 객체를 참조한다면 jpa 내부에서는 두 객체는 같다.
* 다른 객체라면 instance of 를 사용하여 두 객체가 같은지 확인해야 한다.
* ManyToOne()쪽에 LAZY를 걸지 않으면 N + 1 문제 가 일어난다. <= 참조 해야 할 타 테이블 관련 엔티티를 프록시로 만든다. 
* cascade 영속성 전이는 라이프 사이클이 같거나 하나의 테이블 및 객체와 연관만 있을 경우 사용한다.